### PR TITLE
update to postcss 8

### DIFF
--- a/.rollup.js
+++ b/.rollup.js
@@ -1,15 +1,16 @@
-import babel from 'rollup-plugin-babel';
+import babel from '@rollup/plugin-babel';
 
 export default {
 	input: 'src/index.js',
 	output: [
-		{ file: 'index.cjs.js', format: 'cjs', sourcemap: true, strict: false },
-		{ file: 'index.esm.mjs', format: 'esm', sourcemap: true, strict: false }
+		{ file: 'index.cjs.js', format: 'cjs', sourcemap: true, exports: 'default' },
+		{ file: 'index.esm.mjs', format: 'esm', sourcemap: true, exports: 'default' }
 	],
 	plugins: [
 		babel({
+			babelHelpers: 'bundled',
 			presets: [
-				['@babel/env', { modules: false, targets: { node: 8 } }]
+				['@babel/env', { modules: false, targets: { node: 10 } }]
 			]
 		})
 	]

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@
 language: node_js
 
 node_js:
-  - 8
+  - 10
+  - 12
+  - 14
 
 install:
   - npm install --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:tape": "postcss-tape"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "peerDependencies": {
     "postcss": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "engines": {
     "node": ">=8.0.0"
   },
-  "dependencies": {
-    "postcss": "^7.0.17"
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -36,7 +36,8 @@
     "babel-eslint": "^10.0.1",
     "echint": "^4.0.2",
     "eslint": "^5.16.0",
-    "postcss-tape": "^5.0.0",
+    "postcss": "^8.1.1",
+    "postcss-tape": "^6.0.0",
     "pre-commit": "^1.2.2",
     "rollup": "^1.14.6",
     "rollup-plugin-babel": "^4.3.2"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "build": "rollup --config .rollup.js --silent",
     "prepublishOnly": "npm test",
     "pretest:tape": "npm run build",
-    "test": "npm run test:ec && npm run test:js && npm run test:tape",
-    "test:ec": "echint --ignore index.*.js test",
+    "test": "npm run test:js && npm run test:tape",
     "test:js": "eslint src/{*,**/*}.js --cache --ignore-path .gitignore --quiet",
     "test:tape": "postcss-tape"
   },
@@ -31,16 +30,15 @@
     "postcss": "^8.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
-    "@babel/preset-env": "^7.4.5",
+    "@babel/core": "^7.13.8",
+    "@babel/preset-env": "^7.13.9",
+    "@rollup/plugin-babel": "^5.3.0",
     "babel-eslint": "^10.0.1",
-    "echint": "^4.0.2",
-    "eslint": "^5.16.0",
-    "postcss": "^8.1.1",
+    "eslint": "^7.21.0",
+    "postcss": "^8.2.7",
     "postcss-tape": "^6.0.0",
     "pre-commit": "^1.2.2",
-    "rollup": "^1.14.6",
-    "rollup-plugin-babel": "^4.3.2"
+    "rollup": "^2.40.0"
   },
   "eslintConfig": {
     "env": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
-// tooling
-import postcss from 'postcss';
-
-// internal tooling
 import transformBorder from './lib/transform-border';
 import transformBorderRadius from './lib/transform-border-radius';
 import transformDirectionalShorthands from './lib/transform-directional-shorthands';
@@ -59,7 +55,7 @@ const transformsRegExp = new RegExp(`^(${Object.keys(transforms).join('|')})$`, 
 const unsplitPropRegExp = /^(border-block|border-block-end|border-block-start|border-inline|border-inline-end|border-inline-start)$/i;
 
 // plugin
-export default postcss.plugin('postcss-logical-properties', opts => {
+function postcssLogicalProperties(opts) {
 	opts = Object(opts);
 
 	const preserve = Boolean(opts.preserve);
@@ -69,35 +65,41 @@ export default postcss.plugin('postcss-logical-properties', opts => {
 		: 'ltr'
 	: false;
 
-	return root => {
-		root.walkDecls(transformsRegExp, decl => {
-			const parent = decl.parent;
-			const values = unsplitPropRegExp.test(decl.prop) ? [decl.value] : splitBySpace(decl.value, true);
-			const prop = decl.prop.toLowerCase();
+	return {
+		postcssPlugin: 'postcss-logical-properties',
+		Root: root => {
+			root.walkDecls(transformsRegExp, decl => {
+				const parent = decl.parent;
+				const values = unsplitPropRegExp.test(decl.prop) ? [decl.value] : splitBySpace(decl.value, true);
+				const prop = decl.prop.toLowerCase();
 
-			const replacer = transforms[prop](decl, values, dir);
+				const replacer = transforms[prop](decl, values, dir);
 
-			if (!replacer) {
-				return;
-			}
+				if (!replacer) {
+					return;
+				}
 
-			[].concat(replacer).forEach(replacement => {
-				if (replacement.type === 'rule') {
-					parent.before(replacement);
-				} else {
-					decl.before(replacement);
+				[].concat(replacer).forEach(replacement => {
+					if (replacement.type === 'rule') {
+						parent.before(replacement);
+					} else {
+						decl.before(replacement);
+					}
+				});
+
+				if (preserve) {
+					return;
+				}
+
+				decl.remove();
+
+				if (!parent.nodes.length) {
+					parent.remove();
 				}
 			});
-
-			if (preserve) {
-				return;
-			}
-
-			decl.remove();
-
-			if (!parent.nodes.length) {
-				parent.remove();
-			}
-		});
+		}
 	};
-});
+}
+postcssLogicalProperties.postcss = true;
+
+export default postcssLogicalProperties;


### PR DESCRIPTION
ref https://github.com/csstools/postcss-preset-env/issues/191

This is just a straightforward version bump, using the `Root:` style
postcss 8 plugin. I tried to switch to using `Declaration:`, but that
causes an infinite replacement loop. I could remedy it with some extra
checks in the `transition` transform, but I'm not confident that those
were all the possible infinite loop cases, so I went back to this
single-pass style.