### PR TITLE
fix : #37

### DIFF
--- a/.tape.js
+++ b/.tape.js
@@ -95,5 +95,9 @@ module.exports = {
 			dir: 'ltr',
 			preserve: true
 		}
+	},
+	'atrule_keyframes': {
+		message: 'does not produce invalid css when logical properties are used in @keyframes',
+		options: {}
 	}
 };

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,12 @@ function postcssLogicalProperties(opts) {
 	const makeTransform = (transform) => {
 		return (decl) => {
 			const parent = decl.parent;
+			if (parent.parent && parent.parent.type === 'atrule' && parent.parent.name === 'keyframes') {
+				// https://drafts.csswg.org/css-animations/#typedef-keyframe-selector
+				// keyframe-selector only supports : from | to | <percentage>
+				return;
+			}
+
 			const values = splitBySpace(decl.value, true);
 			transform(decl, values, dir, preserve);
 			if (!parent.nodes.length) {
@@ -35,6 +41,12 @@ function postcssLogicalProperties(opts) {
 	const makeTransformWithoutSplittingValues = (transform) => {
 		return (decl) => {
 			const parent = decl.parent;
+			if (parent.parent && parent.parent.type === 'atrule' && parent.parent.name === 'keyframes') {
+				// https://drafts.csswg.org/css-animations/#typedef-keyframe-selector
+				// keyframe-selector only supports : from | to | <percentage>
+				return;
+			}
+
 			const values = [decl.value];
 			transform(decl, values, dir, preserve);
 			if (!parent.nodes.length) {

--- a/test/atrule_keyframes.css
+++ b/test/atrule_keyframes.css
@@ -1,0 +1,28 @@
+/* see : https://github.com/csstools/postcss-logical/issues/37 */
+@keyframes busy {
+
+	0%,
+	100% {
+		inset-inline-start: 0;
+		inset-inline-end: auto;
+		inline-size: 0;
+	}
+
+	33% {
+		inset-inline-start: 0;
+		inset-inline-end: auto;
+		inline-size: 100%;
+	}
+
+	33.01% {
+		inset-inline-start: auto;
+		inset-inline-end: 0;
+		inline-size: 100%;
+	}
+
+	66% {
+		inset-inline-start: auto;
+		inset-inline-end: 0;
+		inline-size: 0;
+	}
+}

--- a/test/atrule_keyframes.expect.css
+++ b/test/atrule_keyframes.expect.css
@@ -1,0 +1,28 @@
+/* see : https://github.com/csstools/postcss-logical/issues/37 */
+@keyframes busy {
+
+	0%,
+	100% {
+		inset-inline-start: 0;
+		inset-inline-end: auto;
+		inline-size: 0;
+	}
+
+	33% {
+		inset-inline-start: 0;
+		inset-inline-end: auto;
+		inline-size: 100%;
+	}
+
+	33.01% {
+		inset-inline-start: auto;
+		inset-inline-end: 0;
+		inline-size: 100%;
+	}
+
+	66% {
+		inset-inline-start: auto;
+		inset-inline-end: 0;
+		inline-size: 0;
+	}
+}


### PR DESCRIPTION
Relevant spec pieces :

https://drafts.csswg.org/css-animations/#typedef-keyframe-selector

> \<keyframe-selector\> = from | to | <percentage>

> The \<rule-list\> inside of @keyframes can only contain \<keyframe-block\> rules.

Any selector change inside `@keyframes` will always be invalid I think.

Simply checking for `decl.parent.parent` for an `@keyframes` rule should be a solid way to detect this.

----------

This does not enable logical properties inside `@keyframes` but it does allow people to manually write valid `@keyframes`.